### PR TITLE
fix: add KMS CMK encryption to S3 bucket (AWS-0132)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,27 @@
+resource "aws_kms_key" "s3" {
+  description             = "KMS key for S3 bucket encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  tags = var.tags
+}
+
 module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> 4.0"
 
   bucket        = var.bucket_name
   force_destroy = true
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm     = "aws:kms"
+        kms_master_key_id = aws_kms_key.s3.arn
+      }
+      bucket_key_enabled = true
+    }
+  }
 
   tags = var.tags
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,8 @@ output "bucket_region" {
   description = "Region of the created S3 bucket"
   value       = module.s3_bucket.s3_bucket_region
 }
+
+output "kms_key_arn" {
+  description = "ARN of the KMS key used for bucket encryption"
+  value       = aws_kms_key.s3.arn
+}


### PR DESCRIPTION
## Summary
- Adds an `aws_kms_key` resource with automatic key rotation enabled
- Configures the S3 bucket module with SSE-KMS using the customer managed key
- Enables S3 Bucket Key to reduce KMS API costs
- Exports the KMS key ARN as a new output

Resolves trivy HIGH finding **AWS-0132**: *Bucket does not encrypt data with a customer managed key.*

## Test plan
- [ ] `terraform init && terraform validate` passes
- [ ] `terraform plan` shows the new KMS key and updated bucket encryption config
- [ ] Re-run trivy scan confirms AWS-0132 is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)